### PR TITLE
Adding clear_override flags to all PACMod 3 commands.

### DIFF
--- a/pacmod_msgs/msg/SteerSystemCmd.msg
+++ b/pacmod_msgs/msg/SteerSystemCmd.msg
@@ -2,6 +2,7 @@ Header header
 
 bool enable
 bool ignore_overrides
+bool clear_override
 
 float64 command
 float64 rotation_rate

--- a/pacmod_msgs/msg/SystemCmdBool.msg
+++ b/pacmod_msgs/msg/SystemCmdBool.msg
@@ -2,5 +2,6 @@ Header header
 
 bool enable
 bool ignore_overrides
+bool clear_override
 
 bool command

--- a/pacmod_msgs/msg/SystemCmdFloat.msg
+++ b/pacmod_msgs/msg/SystemCmdFloat.msg
@@ -2,5 +2,6 @@ Header header
 
 bool enable
 bool ignore_overrides
+bool clear_override
 
 float64 command

--- a/pacmod_msgs/msg/SystemCmdInt.msg
+++ b/pacmod_msgs/msg/SystemCmdInt.msg
@@ -2,6 +2,7 @@ Header header
 
 bool enable
 bool ignore_overrides
+bool clear_override
 
 uint16 command
 


### PR DESCRIPTION
This flag needs to be set to clear an override on any system which
encounters one.