### PR TITLE
Adding config_fault_active to the PACMod Global Report.

### DIFF
--- a/pacmod_msgs/msg/GlobalRpt.msg
+++ b/pacmod_msgs/msg/GlobalRpt.msg
@@ -3,6 +3,7 @@ Header header
 bool enabled                # Indicates whether any system on the PACMod is enabled or disabled.
 bool override_active        # Indicates whether an override has been triggered on any system.
 bool fault_active           # Indicates whether a fault is active on any system.
+bool config_fault_active    # Indicates whether the CONFIG.TXT file was read correctly
 bool user_can_timeout       # Indicates a timeout has been exceeded on the user CAN interface.
 bool brake_can_timeout      # Indicates a timeout has been exceeded on the brake CAN interface.
 bool steering_can_timeout   # Indicates a timeout has been exceeded on the steering CAN interface.


### PR DESCRIPTION
This allows reporting of a configuration fault when CONFIG.TXT
could not be read correctly.