### PR TITLE
ROS1/2 Hybrid: delphi_esr_msgs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,9 +56,38 @@ jobs:
             catkin_test_results
     working_directory: ~/src
 
+  dashing:
+    docker:
+      - image: autonomoustuff/docker-builds:dashing-ros-base
+    steps:
+      - checkout
+      - run:
+          name: Set Up Container
+          command: |
+            apt-get update -qq
+            source `find /opt/ros -maxdepth 2 -name local_setup.bash | sort | head -1`
+            rosdep update
+            rosdep install --from-paths . --ignore-src -y
+            cd ..
+      - run:
+          name: Build
+          command: |
+            source `find /opt/ros -maxdepth 2 -name local_setup.bash | sort | head -1`
+            cd ..
+            colcon build --packages-up-to delphi_esr_msgs
+      - run:
+          name: Run Tests
+          command: |
+            source `find /opt/ros -maxdepth 2 -name local_setup.bash | sort | head -1`
+            cd ..
+            colcon test --packages-up-to delphi_esr_msgs
+            colcon test-result
+    working_directory: ~/src
+
 workflows:
   version: 2
   ros_build:
     jobs:
       - kinetic
       - melodic
+      - dashing

--- a/astuff_sensor_msgs/package.xml
+++ b/astuff_sensor_msgs/package.xml
@@ -1,30 +1,31 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>astuff_sensor_msgs</name>
   <version>2.3.1</version>
   <description>Messages specific to AStuff-provided sensors.</description>
+  <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Development Team</maintainer>
   <license>MIT</license>
-
   <url type="website">http://wiki.ros.org/astuff_sensor_msgs</url>
   <url type="repository">https://github.com/astuff/astuff_sensor_msgs</url>
   <url type="bugtracker">https://github.com/astuff/astuff_sensor_msgs/issues</url>
-
-  <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Development Team</maintainer>
   <author email="jwhitley@autonomoustuff.com">Joshua Whitley</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
 
   <exec_depend>delphi_esr_msgs</exec_depend>
   <exec_depend>delphi_srr_msgs</exec_depend>
+  <exec_depend>derived_object_msgs</exec_depend>
   <exec_depend>ibeo_msgs</exec_depend>
   <exec_depend>kartech_linear_actuator_msgs</exec_depend>
   <exec_depend>mobileye_560_660_msgs</exec_depend>
   <exec_depend>neobotix_usboard_msgs</exec_depend>
   <exec_depend>pacmod_msgs</exec_depend>
   <exec_depend>radar_msgs</exec_depend>
-  <exec_depend>derived_object_msgs</exec_depend>
 
   <export>
-    <metapackage />
+    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
+    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
   </export>
 </package>

--- a/delphi_esr_msgs/CMakeLists.txt
+++ b/delphi_esr_msgs/CMakeLists.txt
@@ -1,45 +1,94 @@
-cmake_minimum_required(VERSION 2.8.3)
 project(delphi_esr_msgs)
 
-add_definitions(-std=c++11)
+set(ROS_VERSION $ENV{ROS_VERSION})
 
-set(CMAKE_CXX_FLAGS "-std=c++0x ${CMAKE_CXX_FLAGS}")
+set(MSG_FILES
+  "EsrEthTx.msg"
+  "EsrStatus1.msg"
+  "EsrStatus2.msg"
+  "EsrStatus3.msg"
+  "EsrStatus4.msg"
+  "EsrStatus5.msg"
+  "EsrStatus6.msg"
+  "EsrStatus7.msg"
+  "EsrStatus8.msg"
+  "EsrStatus9.msg"
+  "EsrTrack.msg"
+  "EsrTrackMotionPower.msg"
+  "EsrValid1.msg"
+  "EsrValid2.msg"
+  "EsrVehicle1.msg"
+  "EsrVehicle2.msg"
+  "EsrVehicle3.msg"
+  "EsrVehicle4.msg"
+  "EsrVehicle5.msg"
+  "TrackMotionPower.msg"
+)
 
-find_package(catkin REQUIRED COMPONENTS
+if(${ROS_VERSION} EQUAL 1)
+
+  cmake_minimum_required(VERSION 2.8.3)
+
+  # Default to C++11
+  if(NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 11)
+  endif()
+
+  find_package(catkin REQUIRED
+    COMPONENTS
     message_generation
     std_msgs
-)
+  )
 
-## Generate messages in the 'msg' folder
-add_message_files(
-  FILES
-  EsrEthTx.msg
-  # can Tx
-  EsrStatus1.msg
-  EsrStatus2.msg
-  EsrStatus3.msg
-  EsrStatus4.msg
-  EsrStatus5.msg
-  EsrStatus6.msg
-  EsrStatus7.msg
-  EsrStatus8.msg
-  EsrStatus9.msg
-  EsrValid1.msg
-  EsrValid2.msg
-  EsrTrack.msg
-  EsrTrackMotionPower.msg
-  TrackMotionPower.msg
-  # can Rx
-  EsrVehicle1.msg
-  EsrVehicle2.msg
-  EsrVehicle3.msg
-  EsrVehicle4.msg
-  EsrVehicle5.msg
-)
+  add_message_files(FILES
+    ${MSG_FILES}
+    DIRECTORY msg
+  )
 
-generate_messages(DEPENDENCIES std_msgs)
+  generate_messages(DEPENDENCIES std_msgs)
 
-catkin_package(CATKIN_DEPENDS
-  message_runtime
-  std_msgs
-)
+  catkin_package(
+    CATKIN_DEPENDS message_runtime
+  )
+
+elseif(${ROS_VERSION} EQUAL 2)
+
+  cmake_minimum_required(VERSION 3.5)
+
+  if(NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_CXX_STANDARD 14)
+  endif()
+
+  if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-Wall -Wextra -Wpedantic)
+  endif()
+
+  find_package(ament_cmake REQUIRED)
+  find_package(builtin_interfaces REQUIRED)
+  find_package(std_msgs REQUIRED)
+  find_package(rosidl_default_generators REQUIRED)
+
+  # Apend "msg/" to each file name
+  set(TEMP_LIST "")
+  foreach(MSG_FILE ${MSG_FILES})
+    list(APPEND TEMP_LIST "msg/${MSG_FILE}")
+  endforeach()
+  set(MSG_FILES ${TEMP_LIST})
+
+  rosidl_generate_interfaces(${PROJECT_NAME}
+    ${MSG_FILES}
+    DEPENDENCIES builtin_interfaces std_msgs
+    ADD_LINTER_TESTS
+  )
+
+  ament_export_dependencies(rosidl_default_runtime)
+
+  if(BUILD_TESTING)
+    find_package(ament_lint_auto REQUIRED)
+    ament_lint_auto_find_test_dependencies()
+  endif()
+
+  ament_package()
+
+endif()

--- a/delphi_esr_msgs/migration/EsrStatus1.bmr
+++ b/delphi_esr_msgs/migration/EsrStatus1.bmr
@@ -1,0 +1,81 @@
+class update_delphi_esr_msgs_EsrStatus1_2bab6477be87782f9154c54c75ec5117(MessageUpdateRule):
+	old_type = "delphi_esr_msgs/EsrStatus1"
+	old_full_text = """
+Header header
+
+# ESR status1
+string      canmsg
+uint8       timeStamp
+uint8       rollingCount
+bool        commError
+int16       curvature
+uint16      scanId
+float32     yawRate
+float32     vehicleSpeedCalc
+
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	new_type = "delphi_esr_msgs/EsrStatus1"
+	new_full_text = """
+std_msgs/Header header
+
+# ESR status1
+string      canmsg
+uint8       time_stamp
+uint8       rolling_count
+bool        comm_error
+int16       curvature
+uint16      scan_id
+float32     yaw_rate
+float32     vehicle_speed_calc
+
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	order = 0
+	migrated_types = [
+		("Header","Header"),]
+
+	valid = True
+
+	def update(self, old_msg, new_msg):
+		self.migrate(old_msg.header, new_msg.header)
+		new_msg.canmsg = old_msg.canmsg
+		new_msg.time_stamp = old_msg.timeStamp
+		new_msg.rolling_count = old_msg.rollingCount
+		new_msg.comm_error = old_msg.commError
+		new_msg.curvature = old_msg.curvature
+		new_msg.scan_id = old_msg.scanId
+		new_msg.yaw_rate = old_msg.yawRate
+		new_msg.vehicle_speed_calc = old_msg.vehicleSpeedCalc

--- a/delphi_esr_msgs/migration/EsrStatus2.bmr
+++ b/delphi_esr_msgs/migration/EsrStatus2.bmr
@@ -1,0 +1,98 @@
+class update_delphi_esr_msgs_EsrStatus2_bcf53fd3f623189a15116de844ce9791(MessageUpdateRule):
+	old_type = "delphi_esr_msgs/EsrStatus2"
+	old_full_text = """
+Header header
+
+# ESR status2
+string      canmsg
+uint8       rollingCount2
+uint8       maxTrackAck
+bool        overheatError
+bool        rangePerfError
+bool        internalError
+bool        xcvrOperational
+bool        rawDataMode
+uint16      steerAngleAck
+int8        temperature
+float32     spdCompFactor
+uint8       groupingMode
+float32     yawRateBias
+string      swVersionDSP     
+
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	new_type = "delphi_esr_msgs/EsrStatus2"
+	new_full_text = """
+std_msgs/Header header
+
+# ESR status2
+string      canmsg
+uint8       rolling_count2
+uint8       max_track_ack
+bool        overheat_error
+bool        range_perf_error
+bool        internal_error
+bool        xcvr_operational
+bool        raw_data_mode
+uint16      steer_angle_ack
+int8        temperature
+float32     spd_comp_factor
+uint8       grouping_mode
+float32     yaw_rate_bias
+string      sw_version_dsp
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	order = 0
+	migrated_types = [
+		("Header","Header"),]
+
+	valid = True
+
+	def update(self, old_msg, new_msg):
+		self.migrate(old_msg.header, new_msg.header)
+		new_msg.canmsg = old_msg.canmsg
+		new_msg.rolling_count2 = old_msg.rollingCount2
+		new_msg.max_track_ack = old_msg.maxTrackAck
+		new_msg.overheat_error = old_msg.overheatError
+		new_msg.range_perf_error = old_msg.rangePerfError
+		new_msg.internal_error = old_msg.internalError
+		new_msg.xcvr_operational = old_msg.xcvrOperational
+		new_msg.raw_data_mode = old_msg.rawDataMode
+		new_msg.steer_angle_ack = old_msg.steerAngleAck
+		new_msg.temperature = old_msg.temperature
+		new_msg.spd_comp_factor = old_msg.spdCompFactor
+		new_msg.grouping_mode = old_msg.groupingMode
+		new_msg.yaw_rate_bias = old_msg.yawRateBias
+		new_msg.sw_version_dsp = old_msg.swVersionDSP

--- a/delphi_esr_msgs/migration/EsrStatus3.bmr
+++ b/delphi_esr_msgs/migration/EsrStatus3.bmr
@@ -1,0 +1,75 @@
+class update_delphi_esr_msgs_EsrStatus3_d267bafb7654adc3b6ab9a341e242e48(MessageUpdateRule):
+	old_type = "delphi_esr_msgs/EsrStatus3"
+	old_full_text = """
+Header header
+
+# ESR status3
+string      canmsg
+uint8      hwVersion
+uint8      interfaceVersion
+uint8      swVersionPld
+string      swVersionHost
+string      serialNum
+
+
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	new_type = "delphi_esr_msgs/EsrStatus3"
+	new_full_text = """
+std_msgs/Header header
+
+# ESR status3
+string      canmsg
+uint8       hw_version
+uint8       interface_version
+uint8       sw_version_pld
+string      sw_version_host
+string      serial_num
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	order = 0
+	migrated_types = [
+		("Header","Header"),]
+
+	valid = True
+
+	def update(self, old_msg, new_msg):
+		self.migrate(old_msg.header, new_msg.header)
+		new_msg.canmsg = old_msg.canmsg
+		new_msg.hw_version = old_msg.hwVersion
+		new_msg.interface_version = old_msg.interfaceVersion
+		new_msg.sw_version_pld = old_msg.swVersionPld
+		new_msg.sw_version_host = old_msg.swVersionHost
+		new_msg.serial_num = old_msg.serialNum

--- a/delphi_esr_msgs/migration/EsrStatus4.bmr
+++ b/delphi_esr_msgs/migration/EsrStatus4.bmr
@@ -1,0 +1,101 @@
+class update_delphi_esr_msgs_EsrStatus4_abec2ac03bbfc0ae47f593463cff96cc(MessageUpdateRule):
+	old_type = "delphi_esr_msgs/EsrStatus4"
+	old_full_text = """
+Header header
+
+# ESR status4
+string      canmsg
+uint8       rollingCount3
+uint8       mrlrMode
+bool        patialBlockage
+bool        sideLobeBlockage
+bool        lrOnlyGratingLobeDet
+bool        truckTargetDet
+uint8       pathIdAcc
+uint8       pathIdCmmbMove
+uint8       pathIdCmmbStat
+uint8       pathIdFcwMove
+uint8       pathIdFcwStat
+uint8       pathIdAccStat
+float32     autoAlginAngle
+
+
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	new_type = "delphi_esr_msgs/EsrStatus4"
+	new_full_text = """
+std_msgs/Header header
+
+# ESR status4
+string      canmsg
+uint8       rolling_count3
+uint8       mrlr_mode
+bool        patial_blockage
+bool        side_lobe_blockage
+bool        lr_only_grating_lobe_det
+bool        truck_target_det
+uint8       path_id_acc
+uint8       path_id_cmmb_move
+uint8       path_id_cmmb_stat
+uint8       path_id_fcw_move
+uint8       path_id_fcw_stat
+uint8       path_id_acc_stat
+float32     auto_algin_angle
+
+
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	order = 0
+	migrated_types = [
+		("Header","Header"),]
+
+	valid = True
+
+	def update(self, old_msg, new_msg):
+		self.migrate(old_msg.header, new_msg.header)
+		new_msg.canmsg = old_msg.canmsg
+		new_msg.rolling_count3 = old_msg.rollingCount3
+		new_msg.mrlr_mode = old_msg.mrlrMode
+		new_msg.patial_blockage = old_msg.patialBlockage
+		new_msg.side_lobe_blockage = old_msg.sideLobeBlockage
+		new_msg.lr_only_grating_lobe_det = old_msg.lrOnlyGratingLobeDet
+		new_msg.truck_target_det = old_msg.truckTargetDet
+		new_msg.path_id_acc = old_msg.pathIdAcc
+		new_msg.path_id_cmmb_move = old_msg.pathIdCmmbMove
+		new_msg.path_id_cmmb_stat = old_msg.pathIdCmmbStat
+		new_msg.path_id_fcw_move = old_msg.pathIdFcwMove
+		new_msg.path_id_fcw_stat = old_msg.pathIdFcwStat
+		new_msg.path_id_acc_stat = old_msg.pathIdAccStat
+		new_msg.auto_algin_angle = old_msg.autoAlginAngle

--- a/delphi_esr_msgs/migration/EsrStatus5.bmr
+++ b/delphi_esr_msgs/migration/EsrStatus5.bmr
@@ -1,0 +1,86 @@
+class update_delphi_esr_msgs_EsrStatus5_aae12ba774492012b782362919f8cb63(MessageUpdateRule):
+	old_type = "delphi_esr_msgs/EsrStatus5"
+	old_full_text = """
+Header header
+
+# ESR status5
+string      canmsg
+uint8       swbattA2D
+uint8       ignpA2D
+uint8       temp1A2D
+uint8       temp2A2D
+uint8       supply5VA
+uint8       supply5VDX
+uint8       supply53P3V
+uint8       supply10V
+
+
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	new_type = "delphi_esr_msgs/EsrStatus5"
+	new_full_text = """
+std_msgs/Header header
+
+# ESR status5
+string      canmsg
+uint8       swbatt_a2d
+uint8       ignp_a2d
+uint8       temp1_a2d
+uint8       temp2_a2d
+uint8       supply_5v_a
+uint8       supply_5v_dx
+uint8       supply_53p_3v
+uint8       supply_10_v
+
+
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	order = 0
+	migrated_types = [
+		("Header","Header"),]
+
+	valid = True
+
+	def update(self, old_msg, new_msg):
+		self.migrate(old_msg.header, new_msg.header)
+		new_msg.canmsg = old_msg.canmsg
+		new_msg.swbatt_a2d = old_msg.swbattA2D
+		new_msg.ignp_a2d = old_msg.ignpA2D
+		new_msg.temp1_a2d = old_msg.temp1A2D
+		new_msg.temp2_a2d = old_msg.temp2A2D
+		new_msg.supply_5v_a = old_msg.supply5VA
+		new_msg.supply_5v_dx = old_msg.supply5VDX
+		new_msg.supply_53p_3v = old_msg.supply53P3V
+		new_msg.supply_10_v = old_msg.supply10V

--- a/delphi_esr_msgs/migration/EsrStatus6.bmr
+++ b/delphi_esr_msgs/migration/EsrStatus6.bmr
@@ -1,0 +1,98 @@
+class update_delphi_esr_msgs_EsrStatus6_fab6045bfaa2bc768f235e17159502ea(MessageUpdateRule):
+	old_type = "delphi_esr_msgs/EsrStatus6"
+	old_full_text = """
+Header header
+
+# ESR status6
+string      canmsg
+uint8       supply1P8V
+uint8       supplyN5V
+uint8       waveDiffA2D
+uint8       swVersionDSP3rdByte
+bool        verticalAlginUpdated
+uint8       systemPowerMode
+bool        foundTarget
+bool        recommendUnconverge
+uint8       factoryAlginStatus1
+uint8       factoryAlginStatus2
+float32     factoryMisAlginment
+uint8       servAlginUpdatesDone
+float32     verticalMisAlginment
+
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	new_type = "delphi_esr_msgs/EsrStatus6"
+	new_full_text = """
+std_msgs/Header header
+
+# ESR status6
+string      canmsg
+uint8       supply_1p_8v
+uint8       supply_n_5v
+uint8       wave_diff_a2d
+uint8       sw_version_dsp_3rd_byte
+bool        vertical_algin_updated
+uint8       system_power_mode
+bool        found_target
+bool        recommend_unconverge
+uint8       factory_algin_status1
+uint8       factory_algin_status2
+float32     factory_mis_alginment
+uint8       serv_algin_updates_done
+float32     vertical_mis_alginment
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	order = 0
+	migrated_types = [
+		("Header","Header"),]
+
+	valid = True
+
+	def update(self, old_msg, new_msg):
+		self.migrate(old_msg.header, new_msg.header)
+		new_msg.canmsg = old_msg.canmsg
+		new_msg.supply_1p_8v = old_msg.supply1P8V
+		new_msg.supply_n_5v = old_msg.supplyN5V
+		new_msg.wave_diff_a2d = old_msg.waveDiffA2D
+		new_msg.sw_version_dsp_3rd_byte = old_msg.swVersionDSP3rdByte
+		new_msg.vertical_algin_updated = old_msg.verticalAlginUpdated
+		new_msg.system_power_mode = old_msg.systemPowerMode
+		new_msg.found_target = old_msg.foundTarget
+		new_msg.recommend_unconverge = old_msg.recommendUnconverge
+		new_msg.factory_algin_status1 = old_msg.factoryAlginStatus1
+		new_msg.factory_algin_status2 = old_msg.factoryAlginStatus2
+		new_msg.factory_mis_alginment = old_msg.factoryMisAlginment
+		new_msg.serv_algin_updates_done = old_msg.servAlginUpdatesDone
+		new_msg.vertical_mis_alginment = old_msg.verticalMisAlginment

--- a/delphi_esr_msgs/migration/EsrStatus7.bmr
+++ b/delphi_esr_msgs/migration/EsrStatus7.bmr
@@ -1,0 +1,84 @@
+class update_delphi_esr_msgs_EsrStatus7_b04af575c0721e778fa727e03d332233(MessageUpdateRule):
+	old_type = "delphi_esr_msgs/EsrStatus7"
+	old_full_text = """
+Header header
+
+# ESR status7
+string      canmsg
+uint8       activeFault0
+uint8       activeFault1
+uint8       activeFault2
+uint8       activeFault3
+uint8       activeFault4
+uint8       activeFault5
+uint8       activeFault6
+uint8       activeFault7
+
+
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	new_type = "delphi_esr_msgs/EsrStatus7"
+	new_full_text = """
+std_msgs/Header header
+
+# ESR status7
+string      canmsg
+uint8       active_fault0
+uint8       active_fault1
+uint8       active_fault2
+uint8       active_fault3
+uint8       active_fault4
+uint8       active_fault5
+uint8       active_fault6
+uint8       active_fault7
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	order = 0
+	migrated_types = [
+		("Header","Header"),]
+
+	valid = True
+
+	def update(self, old_msg, new_msg):
+		self.migrate(old_msg.header, new_msg.header)
+		new_msg.canmsg = old_msg.canmsg
+		new_msg.active_fault0 = old_msg.activeFault0
+		new_msg.active_fault1 = old_msg.activeFault1
+		new_msg.active_fault2 = old_msg.activeFault2
+		new_msg.active_fault3 = old_msg.activeFault3
+		new_msg.active_fault4 = old_msg.activeFault4
+		new_msg.active_fault5 = old_msg.activeFault5
+		new_msg.active_fault6 = old_msg.activeFault6
+		new_msg.active_fault7 = old_msg.activeFault7

--- a/delphi_esr_msgs/migration/EsrStatus8.bmr
+++ b/delphi_esr_msgs/migration/EsrStatus8.bmr
@@ -1,0 +1,84 @@
+class update_delphi_esr_msgs_EsrStatus8_cf0bfab7682c50ee2545f1e97677b621(MessageUpdateRule):
+	old_type = "delphi_esr_msgs/EsrStatus8"
+	old_full_text = """
+Header header
+
+# ESR status8
+string      canmsg
+uint8       historyFault0
+uint8       historyFault1
+uint8       historyFault2
+uint8       historyFault3
+uint8       historyFault4
+uint8       historyFault5
+uint8       historyFault6
+uint8       historyFault7
+
+
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	new_type = "delphi_esr_msgs/EsrStatus8"
+	new_full_text = """
+std_msgs/Header header
+
+# ESR status8
+string      canmsg
+uint8       history_fault0
+uint8       history_fault1
+uint8       history_fault2
+uint8       history_fault3
+uint8       history_fault4
+uint8       history_fault5
+uint8       history_fault6
+uint8       history_fault7
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	order = 0
+	migrated_types = [
+		("Header","Header"),]
+
+	valid = True
+
+	def update(self, old_msg, new_msg):
+		self.migrate(old_msg.header, new_msg.header)
+		new_msg.canmsg = old_msg.canmsg
+		new_msg.history_fault0 = old_msg.historyFault0
+		new_msg.history_fault1 = old_msg.historyFault1
+		new_msg.history_fault2 = old_msg.historyFault2
+		new_msg.history_fault3 = old_msg.historyFault3
+		new_msg.history_fault4 = old_msg.historyFault4
+		new_msg.history_fault5 = old_msg.historyFault5
+		new_msg.history_fault6 = old_msg.historyFault6
+		new_msg.history_fault7 = old_msg.historyFault7

--- a/delphi_esr_msgs/migration/EsrStatus9.bmr
+++ b/delphi_esr_msgs/migration/EsrStatus9.bmr
@@ -1,0 +1,81 @@
+class update_delphi_esr_msgs_EsrStatus9_fc4ded94c686bdf234c4ceb10632e67c(MessageUpdateRule):
+	old_type = "delphi_esr_msgs/EsrStatus9"
+	old_full_text = """
+Header header
+
+# ESR status9
+string      canmsg
+uint16      avgPwrCwblkg
+float32     sideSlipAngle
+uint8       serialNum3rdByte
+uint8       waterSprayTargetID
+float32     filteredXohpAccCIPV
+uint8       pathIDACC2
+uint8       pathIDACC3
+
+
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	new_type = "delphi_esr_msgs/EsrStatus9"
+	new_full_text = """
+std_msgs/Header header
+
+# ESR status9
+string      canmsg
+uint16      avg_pwr_cwblkg
+float32     side_slip_angle
+uint8       serial_num3rd_byte
+uint8       water_spray_target_id
+float32     filtered_xohp_acc_cipv
+uint8       path_id_acc2
+uint8       path_id_acc3
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	order = 0
+	migrated_types = [
+		("Header","Header"),]
+
+	valid = True
+
+	def update(self, old_msg, new_msg):
+		self.migrate(old_msg.header, new_msg.header)
+		new_msg.canmsg = old_msg.canmsg
+		new_msg.avg_pwr_cwblkg = old_msg.avgPwrCwblkg
+		new_msg.side_slip_angle = old_msg.sideSlipAngle
+		new_msg.serial_num3rd_byte = old_msg.serialNum3rdByte
+		new_msg.water_spray_target_id = old_msg.waterSprayTargetID
+		new_msg.filtered_xohp_acc_cipv = old_msg.filteredXohpAccCIPV
+		new_msg.path_id_acc2 = old_msg.pathIDACC2
+		new_msg.path_id_acc3 = old_msg.pathIDACC3

--- a/delphi_esr_msgs/migration/EsrTrack.bmr
+++ b/delphi_esr_msgs/migration/EsrTrack.bmr
@@ -1,0 +1,96 @@
+class update_delphi_esr_msgs_EsrTrack_0a9beb5caea714982a56115450f110c7(MessageUpdateRule):
+	old_type = "delphi_esr_msgs/EsrTrack"
+	old_full_text = """
+Header header
+
+# ESR Track Msg
+string        canmsg
+uint8         track_ID
+float32       track_lat_rate
+bool          track_group_changed
+uint8         track_status
+float32       track_angle
+float32       track_range
+bool          track_bridge_object
+bool          track_rolling_count
+float32       track_width
+float32       track_range_accel
+uint8         track_med_range_mode
+float32       track_range_rate
+
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	new_type = "delphi_esr_msgs/EsrTrack"
+	new_full_text = """
+std_msgs/Header header
+
+# ESR Track Msg
+string        canmsg
+uint8         track_id
+float32       track_lat_rate
+bool          track_group_changed
+uint8         track_status
+float32       track_angle
+float32       track_range
+bool          track_bridge_object
+bool          track_rolling_count
+float32       track_width
+float32       track_range_accel
+uint8         track_med_range_mode
+float32       track_range_rate
+
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	order = 0
+	migrated_types = [
+		("Header","Header"),]
+
+	valid = True
+
+	def update(self, old_msg, new_msg):
+		self.migrate(old_msg.header, new_msg.header)
+		new_msg.canmsg = old_msg.canmsg
+		new_msg.track_id = old_msg.track_ID
+		new_msg.track_lat_rate = old_msg.track_lat_rate
+		new_msg.track_group_changed = old_msg.track_group_changed
+		new_msg.track_status = old_msg.track_status
+		new_msg.track_angle = old_msg.track_angle
+		new_msg.track_range = old_msg.track_range
+		new_msg.track_bridge_object = old_msg.track_bridge_object
+		new_msg.track_rolling_count = old_msg.track_rolling_count
+		new_msg.track_width = old_msg.track_width
+		new_msg.track_range_accel = old_msg.track_range_accel
+		new_msg.track_med_range_mode = old_msg.track_med_range_mode
+		new_msg.track_range_rate = old_msg.track_range_rate

--- a/delphi_esr_msgs/migration/EsrTrackMotionPower.bmr
+++ b/delphi_esr_msgs/migration/EsrTrackMotionPower.bmr
@@ -1,0 +1,109 @@
+class update_delphi_esr_msgs_EsrTrackMotionPower_0e70b42d5a6083ffa1a12dcd74ab9d45(MessageUpdateRule):
+	old_type = "delphi_esr_msgs/EsrTrackMotionPower"
+	old_full_text = """
+Header header
+
+# ESR TrackMotionPower Msg
+string                canmsg
+uint8                 rollingCount
+uint8                 groupId
+TrackMotionPower[]  tracks
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+
+================================================================================
+MSG: delphi_esr_msgs/TrackMotionPower
+bool  movableFast
+bool  movableSlow
+bool  moving
+int8 power
+"""
+
+	new_type = "delphi_esr_msgs/EsrTrackMotionPower"
+	new_full_text = """
+std_msgs/Header header
+
+# ESR TrackMotionPower Msg
+string                              canmsg
+uint8                               rolling_count
+uint8                               group_id
+delphi_esr_msgs/TrackMotionPower[]  tracks
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+
+================================================================================
+MSG: delphi_esr_msgs/TrackMotionPower
+bool  movable_fast
+bool  movable_slow
+bool  moving
+int8  power
+"""
+
+	order = 0
+	migrated_types = [
+		("Header","Header"),
+		("TrackMotionPower","TrackMotionPower"),]
+
+	valid = True
+
+	def update(self, old_msg, new_msg):
+		self.migrate(old_msg.header, new_msg.header)
+		new_msg.canmsg = old_msg.canmsg
+		new_msg.rolling_count = old_msg.rollingCount
+		new_msg.group_id = old_msg.groupId
+		self.migrate_array(old_msg.tracks, new_msg.tracks, "delphi_esr_msgs/TrackMotionPower")
+class update_delphi_esr_msgs_TrackMotionPower_bc0039fe6b619538bc897d0433ea31a8(MessageUpdateRule):
+	old_type = "delphi_esr_msgs/TrackMotionPower"
+	old_full_text = """
+bool  movableFast
+bool  movableSlow
+bool  moving
+int8 power
+"""
+
+	new_type = "delphi_esr_msgs/TrackMotionPower"
+	new_full_text = """
+bool  movable_fast
+bool  movable_slow
+bool  moving
+int8  power
+"""
+
+	order = 0
+	migrated_types = []
+
+	valid = True
+
+	def update(self, old_msg, new_msg):
+		new_msg.movable_fast = old_msg.movableFast
+		new_msg.movable_slow = old_msg.movableSlow
+		new_msg.moving = old_msg.moving
+		new_msg.power = old_msg.power

--- a/delphi_esr_msgs/migration/EsrValid1.bmr
+++ b/delphi_esr_msgs/migration/EsrValid1.bmr
@@ -1,0 +1,74 @@
+class update_delphi_esr_msgs_EsrValid1_c4abfbd505e6dac4796d76d198d45785(MessageUpdateRule):
+	old_type = "delphi_esr_msgs/EsrValid1"
+	old_full_text = """
+Header header
+
+# ESR valid1
+string      canmsg
+uint8       lrSN
+float32     lrRange
+float32     lrRangeRate
+float32     lrAngle
+int8        lrPower
+
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	new_type = "delphi_esr_msgs/EsrValid1"
+	new_full_text = """
+std_msgs/Header header
+
+# ESR valid1
+string      canmsg
+uint8       lr_sn
+float32     lr_range
+float32     lr_range_rate
+float32     lr_angle
+int8        lr_power
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	order = 0
+	migrated_types = [
+		("Header","Header"),]
+
+	valid = True
+
+	def update(self, old_msg, new_msg):
+		self.migrate(old_msg.header, new_msg.header)
+		new_msg.canmsg = old_msg.canmsg
+		new_msg.lr_sn = old_msg.lrSN
+		new_msg.lr_range = old_msg.lrRange
+		new_msg.lr_range_rate = old_msg.lrRangeRate
+		new_msg.lr_angle = old_msg.lrAngle
+		new_msg.lr_power = old_msg.lrPower

--- a/delphi_esr_msgs/migration/EsrValid2.bmr
+++ b/delphi_esr_msgs/migration/EsrValid2.bmr
@@ -1,0 +1,75 @@
+class update_delphi_esr_msgs_EsrValid2_9358feca721eb3835f63862d71ddc71c(MessageUpdateRule):
+	old_type = "delphi_esr_msgs/EsrValid2"
+	old_full_text = """
+Header header
+
+# ESR valid2
+string      canmsg
+uint8       mrSN
+float32     mrRange
+float32     mrRangeRate
+float32     mrAngle
+int8        mrPower
+
+
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	new_type = "delphi_esr_msgs/EsrValid2"
+	new_full_text = """
+std_msgs/Header header
+
+# ESR valid2
+string      canmsg
+uint8       mr_sn
+float32     mr_range
+float32     mr_range_rate
+float32     mr_angle
+int8        mr_power
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	order = 0
+	migrated_types = [
+		("Header","Header"),]
+
+	valid = True
+
+	def update(self, old_msg, new_msg):
+		self.migrate(old_msg.header, new_msg.header)
+		new_msg.canmsg = old_msg.canmsg
+		new_msg.mr_sn = old_msg.mrSN
+		new_msg.mr_range = old_msg.mrRange
+		new_msg.mr_range_rate = old_msg.mrRangeRate
+		new_msg.mr_angle = old_msg.mrAngle
+		new_msg.mr_power = old_msg.mrPower

--- a/delphi_esr_msgs/migration/EsrVehicle4.bmr
+++ b/delphi_esr_msgs/migration/EsrVehicle4.bmr
@@ -1,0 +1,85 @@
+class update_delphi_esr_msgs_EsrVehicle4_0805b9094a6d63c8c5d196257252ccdb(MessageUpdateRule):
+	old_type = "delphi_esr_msgs/EsrVehicle4"
+	old_full_text = """
+Header header
+
+# ESR vehicle4
+bool        fac_align_cmd_1
+bool        fac_align_cmd_2
+uint8       fac_align_max_nt
+uint8       fac_align_samp_req
+int8        fac_tgt_mtg_offset
+int8        fac_tgt_mtg_space_hor
+int8        fac_tgt_mtg_space_ver
+float32     fac_tgt_range_1
+float32     fac_tgt_range_r2m
+float32     fac_tgt_range_m2t
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	new_type = "delphi_esr_msgs/EsrVehicle4"
+	new_full_text = """
+std_msgs/Header header
+
+# ESR vehicle4
+bool        fac_align_cmd1
+bool        fac_align_cmd2
+uint8       fac_align_max_nt
+uint8       fac_align_samp_req
+int8        fac_tgt_mtg_offset
+int8        fac_tgt_mtg_space_hor
+int8        fac_tgt_mtg_space_ver
+float32     fac_tgt_range1
+float32     fac_tgt_range_r2m
+float32     fac_tgt_range_m2t
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	order = 0
+	migrated_types = [
+		("Header","Header"),]
+
+	valid = True
+
+	def update(self, old_msg, new_msg):
+		self.migrate(old_msg.header, new_msg.header)
+		new_msg.fac_align_cmd1 = old_msg.fac_align_cmd_1
+		new_msg.fac_align_cmd2 = old_msg.fac_align_cmd_2
+		new_msg.fac_align_max_nt = old_msg.fac_align_max_nt
+		new_msg.fac_align_samp_req = old_msg.fac_align_samp_req
+		new_msg.fac_tgt_mtg_offset = old_msg.fac_tgt_mtg_offset
+		new_msg.fac_tgt_mtg_space_hor = old_msg.fac_tgt_mtg_space_hor
+		new_msg.fac_tgt_mtg_space_ver = old_msg.fac_tgt_mtg_space_ver
+		new_msg.fac_tgt_range1 = old_msg.fac_tgt_range_1
+		new_msg.fac_tgt_range_r2m = old_msg.fac_tgt_range_r2m
+		new_msg.fac_tgt_range_m2t = old_msg.fac_tgt_range_m2t

--- a/delphi_esr_msgs/migration/TrackMotionPower.bmr
+++ b/delphi_esr_msgs/migration/TrackMotionPower.bmr
@@ -1,0 +1,27 @@
+class update_delphi_esr_msgs_TrackMotionPower_bc0039fe6b619538bc897d0433ea31a8(MessageUpdateRule):
+	old_type = "delphi_esr_msgs/TrackMotionPower"
+	old_full_text = """
+bool  movableFast
+bool  movableSlow
+bool  moving
+int8 power
+"""
+
+	new_type = "delphi_esr_msgs/TrackMotionPower"
+	new_full_text = """
+bool  movable_fast
+bool  movable_slow
+bool  moving
+int8  power
+"""
+
+	order = 1
+	migrated_types = []
+
+	valid = True
+
+	def update(self, old_msg, new_msg):
+		new_msg.movable_fast = old_msg.movableFast
+		new_msg.movable_slow = old_msg.movableSlow
+		new_msg.moving = old_msg.moving
+		new_msg.power = old_msg.power

--- a/delphi_esr_msgs/msg/EsrEthTx.msg
+++ b/delphi_esr_msgs/msg/EsrEthTx.msg
@@ -1,19 +1,19 @@
-Header header
+std_msgs/Header header
 
 # ESR Track Msg
-uint16	      xcp_format_version
-uint16        scan_index
-uint16        tcp_size
-uint8         xcp_scan_type
-uint16        look_index
-uint16        mmr_scan_index
-float32         target_report_host_speed
-float32         target_report_host_yaw_rate
-uint32        xcp_timestamp
-uint8         release_revision
-uint8         promote_revision
-uint8         field_revision
-uint8        target_report_count
+uint16            xcp_format_version
+uint16            scan_index
+uint16            tcp_size
+uint8             xcp_scan_type
+uint16            look_index
+uint16            mmr_scan_index
+float32           target_report_host_speed
+float32           target_report_host_yaw_rate
+uint32            xcp_timestamp
+uint8             release_revision
+uint8             promote_revision
+uint8             field_revision
+uint8             target_report_count
 float32[64]       target_report_range
 float32[64]       target_report_range_rate
 float32[64]       target_report_theta

--- a/delphi_esr_msgs/msg/EsrStatus1.msg
+++ b/delphi_esr_msgs/msg/EsrStatus1.msg
@@ -1,12 +1,12 @@
-Header header
+std_msgs/Header header
 
 # ESR status1
 string      canmsg
-uint8       timeStamp
-uint8       rollingCount
-bool        commError
+uint8       time_stamp
+uint8       rolling_count
+bool        comm_error
 int16       curvature
-uint16      scanId
-float32     yawRate
-float32     vehicleSpeedCalc
+uint16      scan_id
+float32     yaw_rate
+float32     vehicle_speed_calc
 

--- a/delphi_esr_msgs/msg/EsrStatus2.msg
+++ b/delphi_esr_msgs/msg/EsrStatus2.msg
@@ -1,18 +1,17 @@
-Header header
+std_msgs/Header header
 
 # ESR status2
 string      canmsg
-uint8       rollingCount2
-uint8       maxTrackAck
-bool        overheatError
-bool        rangePerfError
-bool        internalError
-bool        xcvrOperational
-bool        rawDataMode
-uint16      steerAngleAck
+uint8       rolling_count2
+uint8       max_track_ack
+bool        overheat_error
+bool        range_perf_error
+bool        internal_error
+bool        xcvr_operational
+bool        raw_data_mode
+uint16      steer_angle_ack
 int8        temperature
-float32     spdCompFactor
-uint8       groupingMode
-float32     yawRateBias
-string      swVersionDSP     
-
+float32     spd_comp_factor
+uint8       grouping_mode
+float32     yaw_rate_bias
+string      sw_version_dsp

--- a/delphi_esr_msgs/msg/EsrStatus3.msg
+++ b/delphi_esr_msgs/msg/EsrStatus3.msg
@@ -1,11 +1,9 @@
-Header header
+std_msgs/Header header
 
 # ESR status3
 string      canmsg
-uint8      hwVersion
-uint8      interfaceVersion
-uint8      swVersionPld
-string      swVersionHost
-string      serialNum
-
-
+uint8       hw_version
+uint8       interface_version
+uint8       sw_version_pld
+string      sw_version_host
+string      serial_num

--- a/delphi_esr_msgs/msg/EsrStatus4.msg
+++ b/delphi_esr_msgs/msg/EsrStatus4.msg
@@ -1,19 +1,19 @@
-Header header
+std_msgs/Header header
 
 # ESR status4
 string      canmsg
-uint8       rollingCount3
-uint8       mrlrMode
-bool        patialBlockage
-bool        sideLobeBlockage
-bool        lrOnlyGratingLobeDet
-bool        truckTargetDet
-uint8       pathIdAcc
-uint8       pathIdCmmbMove
-uint8       pathIdCmmbStat
-uint8       pathIdFcwMove
-uint8       pathIdFcwStat
-uint8       pathIdAccStat
-float32     autoAlginAngle
+uint8       rolling_count3
+uint8       mrlr_mode
+bool        patial_blockage
+bool        side_lobe_blockage
+bool        lr_only_grating_lobe_det
+bool        truck_target_det
+uint8       path_id_acc
+uint8       path_id_cmmb_move
+uint8       path_id_cmmb_stat
+uint8       path_id_fcw_move
+uint8       path_id_fcw_stat
+uint8       path_id_acc_stat
+float32     auto_algin_angle
 
 

--- a/delphi_esr_msgs/msg/EsrStatus5.msg
+++ b/delphi_esr_msgs/msg/EsrStatus5.msg
@@ -1,14 +1,14 @@
-Header header
+std_msgs/Header header
 
 # ESR status5
 string      canmsg
-uint8       swbattA2D
-uint8       ignpA2D
-uint8       temp1A2D
-uint8       temp2A2D
-uint8       supply5VA
-uint8       supply5VDX
-uint8       supply53P3V
-uint8       supply10V
+uint8       swbatt_a2d
+uint8       ignp_a2d
+uint8       temp1_a2d
+uint8       temp2_a2d
+uint8       supply_5v_a
+uint8       supply_5v_dx
+uint8       supply_53p_3v
+uint8       supply_10_v
 
 

--- a/delphi_esr_msgs/msg/EsrStatus6.msg
+++ b/delphi_esr_msgs/msg/EsrStatus6.msg
@@ -1,18 +1,17 @@
-Header header
+std_msgs/Header header
 
 # ESR status6
 string      canmsg
-uint8       supply1P8V
-uint8       supplyN5V
-uint8       waveDiffA2D
-uint8       swVersionDSP3rdByte
-bool        verticalAlginUpdated
-uint8       systemPowerMode
-bool        foundTarget
-bool        recommendUnconverge
-uint8       factoryAlginStatus1
-uint8       factoryAlginStatus2
-float32     factoryMisAlginment
-uint8       servAlginUpdatesDone
-float32     verticalMisAlginment
-
+uint8       supply_1p_8v
+uint8       supply_n_5v
+uint8       wave_diff_a2d
+uint8       sw_version_dsp_3rd_byte
+bool        vertical_algin_updated
+uint8       system_power_mode
+bool        found_target
+bool        recommend_unconverge
+uint8       factory_algin_status1
+uint8       factory_algin_status2
+float32     factory_mis_alginment
+uint8       serv_algin_updates_done
+float32     vertical_mis_alginment

--- a/delphi_esr_msgs/msg/EsrStatus7.msg
+++ b/delphi_esr_msgs/msg/EsrStatus7.msg
@@ -1,14 +1,12 @@
-Header header
+std_msgs/Header header
 
 # ESR status7
 string      canmsg
-uint8       activeFault0
-uint8       activeFault1
-uint8       activeFault2
-uint8       activeFault3
-uint8       activeFault4
-uint8       activeFault5
-uint8       activeFault6
-uint8       activeFault7
-
-
+uint8       active_fault0
+uint8       active_fault1
+uint8       active_fault2
+uint8       active_fault3
+uint8       active_fault4
+uint8       active_fault5
+uint8       active_fault6
+uint8       active_fault7

--- a/delphi_esr_msgs/msg/EsrStatus8.msg
+++ b/delphi_esr_msgs/msg/EsrStatus8.msg
@@ -1,14 +1,12 @@
-Header header
+std_msgs/Header header
 
 # ESR status8
 string      canmsg
-uint8       historyFault0
-uint8       historyFault1
-uint8       historyFault2
-uint8       historyFault3
-uint8       historyFault4
-uint8       historyFault5
-uint8       historyFault6
-uint8       historyFault7
-
-
+uint8       history_fault0
+uint8       history_fault1
+uint8       history_fault2
+uint8       history_fault3
+uint8       history_fault4
+uint8       history_fault5
+uint8       history_fault6
+uint8       history_fault7

--- a/delphi_esr_msgs/msg/EsrStatus9.msg
+++ b/delphi_esr_msgs/msg/EsrStatus9.msg
@@ -1,13 +1,11 @@
-Header header
+std_msgs/Header header
 
 # ESR status9
 string      canmsg
-uint16      avgPwrCwblkg
-float32     sideSlipAngle
-uint8       serialNum3rdByte
-uint8       waterSprayTargetID
-float32     filteredXohpAccCIPV
-uint8       pathIDACC2
-uint8       pathIDACC3
-
-
+uint16      avg_pwr_cwblkg
+float32     side_slip_angle
+uint8       serial_num3rd_byte
+uint8       water_spray_target_id
+float32     filtered_xohp_acc_cipv
+uint8       path_id_acc2
+uint8       path_id_acc3

--- a/delphi_esr_msgs/msg/EsrTrack.msg
+++ b/delphi_esr_msgs/msg/EsrTrack.msg
@@ -1,8 +1,8 @@
-Header header
+std_msgs/Header header
 
 # ESR Track Msg
 string        canmsg
-uint8         track_ID
+uint8         track_id
 float32       track_lat_rate
 bool          track_group_changed
 uint8         track_status

--- a/delphi_esr_msgs/msg/EsrTrackMotionPower.msg
+++ b/delphi_esr_msgs/msg/EsrTrackMotionPower.msg
@@ -1,7 +1,7 @@
-Header header
+std_msgs/Header header
 
 # ESR TrackMotionPower Msg
-string                canmsg
-uint8                 rollingCount
-uint8                 groupId
-TrackMotionPower[]  tracks
+string                              canmsg
+uint8                               rolling_count
+uint8                               group_id
+delphi_esr_msgs/TrackMotionPower[]  tracks

--- a/delphi_esr_msgs/msg/EsrValid1.msg
+++ b/delphi_esr_msgs/msg/EsrValid1.msg
@@ -1,10 +1,9 @@
-Header header
+std_msgs/Header header
 
 # ESR valid1
 string      canmsg
-uint8       lrSN
-float32     lrRange
-float32     lrRangeRate
-float32     lrAngle
-int8        lrPower
-
+uint8       lr_sn
+float32     lr_range
+float32     lr_range_rate
+float32     lr_angle
+int8        lr_power

--- a/delphi_esr_msgs/msg/EsrValid2.msg
+++ b/delphi_esr_msgs/msg/EsrValid2.msg
@@ -1,11 +1,9 @@
-Header header
+std_msgs/Header header
 
 # ESR valid2
 string      canmsg
-uint8       mrSN
-float32     mrRange
-float32     mrRangeRate
-float32     mrAngle
-int8        mrPower
-
-
+uint8       mr_sn
+float32     mr_range
+float32     mr_range_rate
+float32     mr_angle
+int8        mr_power

--- a/delphi_esr_msgs/msg/EsrVehicle1.msg
+++ b/delphi_esr_msgs/msg/EsrVehicle1.msg
@@ -1,4 +1,4 @@
-Header header
+std_msgs/Header header
 
 # ESR vehicle1
 float32     vehicle_speed

--- a/delphi_esr_msgs/msg/EsrVehicle2.msg
+++ b/delphi_esr_msgs/msg/EsrVehicle2.msg
@@ -1,4 +1,4 @@
-Header header
+std_msgs/Header header
 
 # ESR vehicle2
 uint16      scan_index_ack

--- a/delphi_esr_msgs/msg/EsrVehicle3.msg
+++ b/delphi_esr_msgs/msg/EsrVehicle3.msg
@@ -1,4 +1,4 @@
-Header header
+std_msgs/Header header
 
 # ESR vehicle3
 bool        long_accel_valid

--- a/delphi_esr_msgs/msg/EsrVehicle4.msg
+++ b/delphi_esr_msgs/msg/EsrVehicle4.msg
@@ -1,13 +1,13 @@
-Header header
+std_msgs/Header header
 
 # ESR vehicle4
-bool        fac_align_cmd_1
-bool        fac_align_cmd_2
+bool        fac_align_cmd1
+bool        fac_align_cmd2
 uint8       fac_align_max_nt
 uint8       fac_align_samp_req
 int8        fac_tgt_mtg_offset
 int8        fac_tgt_mtg_space_hor
 int8        fac_tgt_mtg_space_ver
-float32     fac_tgt_range_1
+float32     fac_tgt_range1
 float32     fac_tgt_range_r2m
 float32     fac_tgt_range_m2t

--- a/delphi_esr_msgs/msg/EsrVehicle5.msg
+++ b/delphi_esr_msgs/msg/EsrVehicle5.msg
@@ -1,4 +1,4 @@
-Header header
+std_msgs/Header header
 
 # ESR vehicle5
 int8        oversteer_understeer

--- a/delphi_esr_msgs/msg/TrackMotionPower.msg
+++ b/delphi_esr_msgs/msg/TrackMotionPower.msg
@@ -1,4 +1,4 @@
-bool  movableFast
-bool  movableSlow
+bool  movable_fast
+bool  movable_slow
 bool  moving
-int8 power
+int8  power

--- a/delphi_esr_msgs/package.xml
+++ b/delphi_esr_msgs/package.xml
@@ -1,22 +1,37 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>delphi_esr_msgs</name>
   <version>2.3.1</version>
   <description>Message definitions for the Delphi ESR</description>
+  <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Team</maintainer>
   <license>MIT</license>
-
   <url type="website">http://wiki.ros.org/delphi_esr_msgs</url>
   <url type="repository">https://github.com/astuff/astuff_sensor_msgs</url>
   <url type="bugtracker">https://github.com/astuff/astuff_sensor_msgs/issues</url>
-
-  <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Team</maintainer>
   <author email="dstanek@autonomoustuff.com">Daniel Stanek</author>
   <author email="jkale@autonomoustuff.com">Joe Kale</author>
   <author email="jwhitley@autonomoustuff.com">Josh Whitley</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
 
-  <build_depend>message_generation</build_depend>
+  <build_depend condition="$ROS_VERSION == 1">message_generation</build_depend>
+  <build_depend condition="$ROS_VERSION == 2">rosidl_default_generators</build_depend>
+
+  <depend condition="$ROS_VERSION == 2">builtin_interfaces</depend>
   <depend>std_msgs</depend>
-  <exec_depend>message_runtime</exec_depend>
+
+  <exec_depend condition="$ROS_VERSION == 1">message_runtime</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 2">rosidl_default_runtime</exec_depend>
+
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_auto</test_depend>
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
+    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
+  </export>
 </package>

--- a/delphi_esr_msgs/package.xml
+++ b/delphi_esr_msgs/package.xml
@@ -19,6 +19,7 @@
   <build_depend condition="$ROS_VERSION == 1">message_generation</build_depend>
   <build_depend condition="$ROS_VERSION == 2">rosidl_default_generators</build_depend>
 
+  <depend condition="$ROS_VERSION == 1">rosbag_migration_rule</depend>
   <depend condition="$ROS_VERSION == 2">builtin_interfaces</depend>
   <depend>std_msgs</depend>
 
@@ -33,5 +34,20 @@
   <export>
     <build_type condition="$ROS_VERSION == 1">catkin</build_type>
     <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
+    <rosbag_migration_rule rule_file="migration/EsrStatus1.bmr" />
+    <rosbag_migration_rule rule_file="migration/EsrStatus2.bmr" />
+    <rosbag_migration_rule rule_file="migration/EsrStatus3.bmr" />
+    <rosbag_migration_rule rule_file="migration/EsrStatus4.bmr" />
+    <rosbag_migration_rule rule_file="migration/EsrStatus5.bmr" />
+    <rosbag_migration_rule rule_file="migration/EsrStatus6.bmr" />
+    <rosbag_migration_rule rule_file="migration/EsrStatus7.bmr" />
+    <rosbag_migration_rule rule_file="migration/EsrStatus8.bmr" />
+    <rosbag_migration_rule rule_file="migration/EsrStatus9.bmr" />
+    <rosbag_migration_rule rule_file="migration/EsrTrack.bmr" />
+    <rosbag_migration_rule rule_file="migration/EsrTrackMotionPower.bmr" />
+    <rosbag_migration_rule rule_file="migration/EsrValid1.bmr" />
+    <rosbag_migration_rule rule_file="migration/EsrValid2.bmr" />
+    <rosbag_migration_rule rule_file="migration/EsrVehicle4.bmr" />
+    <rosbag_migration_rule rule_file="migration/TrackMotionPower.bmr" />
   </export>
 </package>

--- a/delphi_mrr_msgs/package.xml
+++ b/delphi_mrr_msgs/package.xml
@@ -1,22 +1,37 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>delphi_mrr_msgs</name>
   <version>2.3.1</version>
   <description>Message definitions for the Delphi MRR</description>
-  <license>GPLv3</license>
-
+  <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Team</maintainer>
+  <license>MIT</license>
   <url type="website">http://wiki.ros.org/delphi_mrr_msgs</url>
   <url type="repository">https://github.com/astuff/astuff_sensor_msgs</url>
   <url type="bugtracker">https://github.com/astuff/astuff_sensor_msgs/issues</url>
-
-  <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Team</maintainer>
   <author email="dstanek@autonomoustuff.com">Daniel Stanek</author>
   <author email="jkale@autonomoustuff.com">Joe Kale</author>
   <author email="jwhitley@autonomoustuff.com">Josh Whitley</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
 
-  <build_depend>message_generation</build_depend>
+  <build_depend condition="$ROS_VERSION == 1">message_generation</build_depend>
+  <build_depend condition="$ROS_VERSION == 2">rosidl_default_generators</build_depend>
+
+  <depend condition="$ROS_VERSION == 2">builtin_interfaces</depend>
   <depend>std_msgs</depend>
-  <exec_depend>message_runtime</exec_depend>
+
+  <exec_depend condition="$ROS_VERSION == 1">message_runtime</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 2">rosidl_default_runtime</exec_depend>
+
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_auto</test_depend>
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
+    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
+  </export>
 </package>

--- a/delphi_srr_msgs/package.xml
+++ b/delphi_srr_msgs/package.xml
@@ -1,20 +1,35 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>delphi_srr_msgs</name>
   <version>2.3.1</version>
   <description>Message definitions for the Delphi SRR</description>
+  <maintainer email="support@autonomoustuff.com">AutonomouStuff Software Development Team</maintainer>
   <license>MIT</license>
-
   <url type="website">http://wiki.ros.org/delphi_srr_msgs</url>
   <url type="repository">https://github.com/astuff/astuff_sensor_msgs</url>
   <url type="bugtracker">https://github.com/astuff/astuff_sensor_msgs/issues</url>
-
-  <maintainer email="support@autonomoustuff.com">AutonomouStuff Software Development Team</maintainer>
   <author email="jwhitley@autonomoustuff.com">Josh Whitley</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
 
-  <build_depend>message_generation</build_depend>
+  <build_depend condition="$ROS_VERSION == 1">message_generation</build_depend>
+  <build_depend condition="$ROS_VERSION == 2">rosidl_default_generators</build_depend>
+
+  <depend condition="$ROS_VERSION == 2">builtin_interfaces</depend>
   <depend>std_msgs</depend>
-  <exec_depend>message_runtime</exec_depend>
+
+  <exec_depend condition="$ROS_VERSION == 1">message_runtime</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 2">rosidl_default_runtime</exec_depend>
+
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_auto</test_depend>
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
+    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
+  </export>
 </package>

--- a/derived_object_msgs/package.xml
+++ b/derived_object_msgs/package.xml
@@ -1,26 +1,39 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>derived_object_msgs</name>
   <version>2.3.1</version>
   <description>Abstracted Messages from Perception Modalities</description>
+  <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Development Team</maintainer>
   <license>MIT</license>
-
   <url type="website">http://wiki.ros.org/derived_object_msgs</url>
   <url type="repository">https://github.com/astuff/astuff_sensor_msgs</url>
   <url type="bugtracker">https://github.com/astuff/astuff_sensor_msgs/issues</url>
-
-  <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Development Team</maintainer>
   <author email="dstanek@autonomoustuff.com">Daniel Stanek</author>
   <author email="jwhitley@autonomoustuff.com">Josh Whitley</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
 
-  <build_depend>message_generation</build_depend>
+  <build_depend condition="$ROS_VERSION == 1">message_generation</build_depend>
+  <build_depend condition="$ROS_VERSION == 2">rosidl_default_generators</build_depend>
 
-  <depend>std_msgs</depend>
+  <depend condition="$ROS_VERSION == 2">builtin_interfaces</depend>
   <depend>geometry_msgs</depend>
-  <depend>shape_msgs</depend>
   <depend>radar_msgs</depend>
+  <depend>shape_msgs</depend>
+  <depend>std_msgs</depend>
 
-  <exec_depend>message_runtime</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 1">message_runtime</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 2">rosidl_default_runtime</exec_depend>
+
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_auto</test_depend>
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
+    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
+  </export>
 </package>

--- a/ibeo_msgs/package.xml
+++ b/ibeo_msgs/package.xml
@@ -1,22 +1,35 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>ibeo_msgs</name>
   <version>2.3.1</version>
-  <description>Package containing messages for Ibeo sensors.</description>
+  <description>The ibeo_msgs package</description>
+  <maintainer email="support@autonomoustuff.com">AutonomouStuff Software Team</maintainer>
   <license>MIT</license>
-
-  <url type="website">http://wiki.ros.org/ibeo_msgs</url>
+  <url type="website">http://wiki.ros.org/kartech_linear_actuator_msgs</url>
   <url type="repository">https://github.com/astuff/astuff_sensor_msgs</url>
   <url type="bugtracker">https://github.com/astuff/astuff_sensor_msgs/issues</url>
-
-  <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Team</maintainer>
   <author email="jwhitley@autonomoustuff.com">Joshua Whitley</author>
-  <author email="jkale@autonomoustuff.com">Joe Kale</author>
-  <author email="preed@swri.org">P.J. Reed</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
 
-  <build_depend>message_generation</build_depend>
+  <build_depend condition="$ROS_VERSION == 1">message_generation</build_depend>
+  <build_depend condition="$ROS_VERSION == 2">rosidl_default_generators</build_depend>
+
+  <depend condition="$ROS_VERSION == 2">builtin_interfaces</depend>
   <depend>std_msgs</depend>
-  <exec_depend>message_runtime</exec_depend>
+
+  <exec_depend condition="$ROS_VERSION == 1">message_runtime</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 2">rosidl_default_runtime</exec_depend>
+
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_auto</test_depend>
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
+    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
+  </export>
 </package>

--- a/kartech_linear_actuator_msgs/package.xml
+++ b/kartech_linear_actuator_msgs/package.xml
@@ -1,20 +1,35 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>kartech_linear_actuator_msgs</name>
   <version>2.3.1</version>
   <description>The kartech_linear_actuator_msgs package</description>
+  <maintainer email="support@autonomoustuff.com">AutonomouStuff Software Team</maintainer>
   <license>MIT</license>
-
   <url type="website">http://wiki.ros.org/kartech_linear_actuator_msgs</url>
   <url type="repository">https://github.com/astuff/astuff_sensor_msgs</url>
   <url type="bugtracker">https://github.com/astuff/astuff_sensor_msgs/issues</url>
-
-  <maintainer email="support@autonomoustuff.com">AutonomouStuff Software Team</maintainer>
   <author email="jwhitley@autonomoustuff.com">Joshua Whitley</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
 
-  <build_depend>message_generation</build_depend>
+  <build_depend condition="$ROS_VERSION == 1">message_generation</build_depend>
+  <build_depend condition="$ROS_VERSION == 2">rosidl_default_generators</build_depend>
+
+  <depend condition="$ROS_VERSION == 2">builtin_interfaces</depend>
   <depend>std_msgs</depend>
-  <exec_depend>message_runtime</exec_depend>
+
+  <exec_depend condition="$ROS_VERSION == 1">message_runtime</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 2">rosidl_default_runtime</exec_depend>
+
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_auto</test_depend>
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
+    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
+  </export>
 </package>

--- a/mobileye_560_660_msgs/package.xml
+++ b/mobileye_560_660_msgs/package.xml
@@ -1,20 +1,35 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>mobileye_560_660_msgs</name>
   <version>2.3.1</version>
   <description>Message definitions for the Mobileye 560/660</description>
+  <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Team</maintainer>
   <license>MIT</license>
-
   <url type="website">http://wiki.ros.org/mobileye_560_660_msgs</url>
   <url type="repository">https://github.com/astuff/astuff_sensor_msgs</url>
   <url type="bugtracker">https://github.com/astuff/astuff_sensor_msgs/issues</url>
-
-  <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Team</maintainer>
   <author email="jwhitley@autonomoustuff.com">Josh Whitley</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
 
-  <build_depend>message_generation</build_depend>
+  <build_depend condition="$ROS_VERSION == 1">message_generation</build_depend>
+  <build_depend condition="$ROS_VERSION == 2">rosidl_default_generators</build_depend>
+
+  <depend condition="$ROS_VERSION == 2">builtin_interfaces</depend>
   <depend>std_msgs</depend>
-  <exec_depend>message_runtime</exec_depend>
+
+  <exec_depend condition="$ROS_VERSION == 1">message_runtime</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 2">rosidl_default_runtime</exec_depend>
+
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_auto</test_depend>
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
+    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
+  </export>
 </package>

--- a/neobotix_usboard_msgs/package.xml
+++ b/neobotix_usboard_msgs/package.xml
@@ -1,20 +1,35 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>neobotix_usboard_msgs</name>
   <version>2.3.1</version>
   <description>neobotix_usboard package</description>
+  <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Team</maintainer>
   <license>MIT</license>
-
   <url type="website">http://wiki.ros.org/neobotix_usboard_msgs</url>
   <url type="repository">https://github.com/astuff/astuff_sensor_msgs</url>
   <url type="bugtracker">https://github.com/astuff/astuff_sensor_msgs/issues</url>
-
-  <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Team</maintainer>
   <author email="srustan@autonomoustuff.com">Sam Rustan</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
 
-  <build_depend>message_generation</build_depend>
+  <build_depend condition="$ROS_VERSION == 1">message_generation</build_depend>
+  <build_depend condition="$ROS_VERSION == 2">rosidl_default_generators</build_depend>
+
+  <depend condition="$ROS_VERSION == 2">builtin_interfaces</depend>
   <depend>std_msgs</depend>
-  <exec_depend>message_runtime</exec_depend>
+
+  <exec_depend condition="$ROS_VERSION == 1">message_runtime</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 2">rosidl_default_runtime</exec_depend>
+
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_auto</test_depend>
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
+    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
+  </export>
 </package>

--- a/pacmod_msgs/package.xml
+++ b/pacmod_msgs/package.xml
@@ -1,20 +1,35 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>pacmod_msgs</name>
   <version>2.3.1</version>
   <description>Message definition files for the PACMod driver</description>
+  <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Team</maintainer>
   <license>MIT</license>
-
   <url type="website">http://wiki.ros.org/pacmod_msgs</url>
   <url type="repository">https://github.com/astuff/astuff_sensor_msgs</url>
   <url type="bugtracker">https://github.com/astuff/astuff_sensor_msgs/issues</url>
-
-  <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Team</maintainer>
   <author email="jwhitley@autonomoustuff.com">Josh Whitley</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
 
-  <build_depend>message_generation</build_depend>
+  <build_depend condition="$ROS_VERSION == 1">message_generation</build_depend>
+  <build_depend condition="$ROS_VERSION == 2">rosidl_default_generators</build_depend>
+
+  <depend condition="$ROS_VERSION == 2">builtin_interfaces</depend>
   <depend>std_msgs</depend>
-  <exec_depend>message_runtime</exec_depend>
+
+  <exec_depend condition="$ROS_VERSION == 1">message_runtime</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 2">rosidl_default_runtime</exec_depend>
+
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_auto</test_depend>
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
+    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
+  </export>
 </package>

--- a/radar_msgs/package.xml
+++ b/radar_msgs/package.xml
@@ -1,22 +1,37 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>radar_msgs</name>
   <version>2.3.1</version>
   <description>Generic Radar Messages</description>
+  <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Development Team</maintainer>
   <license>MIT</license>
-
   <url type="website">http://wiki.ros.org/radar_msgs</url>
   <url type="repository">https://github.com/astuff/astuff_sensor_msgs</url>
   <url type="bugtracker">https://github.com/astuff/astuff_sensor_msgs/issues</url>
-
-  <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Development Team</maintainer>
   <author email="dstanek@autonomoustuff.com">Daniel Stanek</author>
   <author email="jwhitley@autonomoustuff.com">Josh Whitley</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
 
-  <build_depend>message_generation</build_depend>
-  <depend>std_msgs</depend>
+  <build_depend condition="$ROS_VERSION == 1">message_generation</build_depend>
+  <build_depend condition="$ROS_VERSION == 2">rosidl_default_generators</build_depend>
+
+  <depend condition="$ROS_VERSION == 2">builtin_interfaces</depend>
   <depend>geometry_msgs</depend>
-  <exec_depend>message_runtime</exec_depend>
+  <depend>std_msgs</depend>
+
+  <exec_depend condition="$ROS_VERSION == 1">message_runtime</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 2">rosidl_default_runtime</exec_depend>
+
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_auto</test_depend>
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
+    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
+  </export>
 </package>


### PR DESCRIPTION
This is the first AutonomouStuff message package which is being hybridized to be able to be built in both ROS1 Kinetic/Melodic and ROS2 Dashing. CI on this branch is now running all 3 environments. All packages also got updated `package.xml` files to keep ROS2 CI from breaking during the `rosdep` step. However, this should not affect anything else.

I've included at least one member from each engineering team to make sure that everyone has a chance to give feedback and we don't merge this until we're sure that nothing will break. After the following tasks are complete and I have an accepted review from each team, we will merge this in tandem with the changes to the other nodes that it effects. Here are the items that I know of (currently) that need to be completed before this can be merged:

- [x] Update `ros_delphi_esr` driver to match message changes
- [x] Test all changes on real sensor

If there are other items that need to be updated to coincide with this merge, *please speak up* and I'll add them to this list. Thanks!