### PR TITLE
Remove CipvTrack Message

### DIFF
--- a/derived_object_msgs/CMakeLists.txt
+++ b/derived_object_msgs/CMakeLists.txt
@@ -5,7 +5,6 @@ find_package(ros_environment REQUIRED)
 set(ROS_VERSION $ENV{ROS_VERSION})
 
 set(MSG_FILES
-  "CipvTrack.msg"
   "Lane.msg"
   "LaneModels.msg"
   "Object.msg"
@@ -28,7 +27,6 @@ if(${ROS_VERSION} EQUAL 1)
     COMPONENTS
       geometry_msgs
       message_generation
-      radar_msgs
       shape_msgs
       std_msgs
   )
@@ -41,7 +39,6 @@ if(${ROS_VERSION} EQUAL 1)
   generate_messages(
     DEPENDENCIES
       geometry_msgs
-      radar_msgs
       shape_msgs
       std_msgs
   )
@@ -66,7 +63,6 @@ elseif(${ROS_VERSION} EQUAL 2)
   find_package(ament_cmake REQUIRED)
   find_package(builtin_interfaces REQUIRED)
   find_package(geometry_msgs REQUIRED)
-  find_package(radar_msgs REQUIRED)
   find_package(rosidl_default_generators REQUIRED)
   find_package(shape_msgs REQUIRED)
   find_package(std_msgs REQUIRED)
@@ -85,7 +81,6 @@ elseif(${ROS_VERSION} EQUAL 2)
       geometry_msgs
       shape_msgs
       std_msgs
-      radar_msgs
     ADD_LINTER_TESTS
   )
 

--- a/derived_object_msgs/msg/CipvTrack.msg
+++ b/derived_object_msgs/msg/CipvTrack.msg
@@ -1,6 +1,0 @@
-# Closest In-Path Vehicle Radar Track
-
-std_msgs/Header header
-
-bool is_valid                   # Whether or not the track is a valid CIPV
-radar_msgs/RadarTrack track     # The CIPV track

--- a/derived_object_msgs/package.xml
+++ b/derived_object_msgs/package.xml
@@ -21,7 +21,6 @@
 
   <depend condition="$ROS_VERSION == 2">builtin_interfaces</depend>
   <depend>geometry_msgs</depend>
-  <depend>radar_msgs</depend>
   <depend>shape_msgs</depend>
   <depend>std_msgs</depend>
 


### PR DESCRIPTION
Resolves #61 
This was needed in order to remove the `radar_msgs` dependency from the `derived_object_msgs` package. 

Reminder that this will only apply to ROS Noetic.