### PR TITLE
Add ROS2 Foxy builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,7 @@
-version: 2
-jobs:
-  kinetic:
-    docker:
-      - image: autonomoustuff/docker-builds:kinetic-ros-base
+version: 2.1
+
+commands:
+  ros1_build:
     steps:
       - checkout
       - run:
@@ -26,67 +25,8 @@ jobs:
             cd ..
             catkin run_tests
             catkin_test_results
-    working_directory: ~/src
 
-  melodic:
-    docker:
-      - image: autonomoustuff/docker-builds:melodic-ros-base
-    steps:
-      - checkout
-      - run:
-          name: Set Up Container
-          command: |
-            apt-get update -qq
-            source `find /opt/ros -name setup.bash | sort | head -1`
-            rosdep install --from-paths . --ignore-src -y
-            cd ..
-            catkin init
-            catkin config --extend /opt/ros/$ROS_DISTRO
-      - run:
-          name: Build
-          command: |
-            cd ..
-            catkin build
-      - run:
-          name: Run Tests
-          command: |
-            source `find /opt/ros -name setup.bash | sort | head -1`
-            cd ..
-            catkin run_tests
-            catkin_test_results
-    working_directory: ~/src
-
-  noetic:
-    docker:
-      - image: autonomoustuff/docker-builds:noetic-ros-base
-    steps:
-      - checkout
-      - run:
-          name: Set Up Container
-          command: |
-            apt-get update -qq
-            source `find /opt/ros -name setup.bash | sort | head -1`
-            rosdep install --from-paths . --ignore-src -y
-            cd ..
-            catkin init
-            catkin config --extend /opt/ros/$ROS_DISTRO
-      - run:
-          name: Build
-          command: |
-            cd ..
-            catkin build
-      - run:
-          name: Run Tests
-          command: |
-            source `find /opt/ros -name setup.bash | sort | head -1`
-            cd ..
-            catkin run_tests
-            catkin_test_results
-    working_directory: ~/src
-
-  dashing:
-    docker:
-      - image: autonomoustuff/docker-builds:dashing-ros-base
+  ros2_build:
     steps:
       - checkout
       - run:
@@ -110,13 +50,49 @@ jobs:
             cd ..
             colcon test
             colcon test-result
+
+jobs:
+  kinetic:
+    docker:
+      - image: autonomoustuff/docker-builds:kinetic-ros-base
+    steps:
+      - ros1_build
+    working_directory: ~/src
+
+  melodic:
+    docker:
+      - image: autonomoustuff/docker-builds:melodic-ros-base
+    steps:
+      - ros1_build
+    working_directory: ~/src
+
+  noetic:
+    docker:
+      - image: autonomoustuff/docker-builds:noetic-ros-base
+    steps:
+      - ros1_build
+    working_directory: ~/src
+
+  dashing:
+    docker:
+      - image: autonomoustuff/docker-builds:dashing-ros-base
+    steps:
+      - ros2_build
+    working_directory: ~/src
+
+  foxy:
+    docker:
+      - image: autonomoustuff/docker-builds:foxy-ros-base
+    steps:
+      - ros2_build
     working_directory: ~/src
 
 workflows:
-  version: 2
+  version: 2.1
   ros_build:
     jobs:
       - kinetic
       - melodic
       - noetic
       - dashing
+      - foxy


### PR DESCRIPTION
Resolves #73 by adding ROS2 Foxy builds. Also made use of [Circle CI's reusable Config](https://circleci.com/docs/2.0/reusing-config/) that is new in version 2.1 to reduce duplication.